### PR TITLE
simplify code when all sampels are combined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Outputs of training runs
 outputs/*
 model*
+data/
 
 *.log
 *.tmp

--- a/conf/download_config.yml
+++ b/conf/download_config.yml
@@ -12,7 +12,7 @@ download:
   extract_samples: False # Whether to extract the samples (one file per sample per chromosome)
   merge_samples: False  # Whether to merge chromosome VCFs for each sample (requires extract_samples)
   compress: True # Whether to save the extracted / merged files as bcf
-  n_samples: 1000  # Number of samples to use
+  n_samples: 5  # Number of samples to use
 
 reference:
   download_reference: True

--- a/test_dataloader.py
+++ b/test_dataloader.py
@@ -86,6 +86,7 @@ def test_dataloader(config, num_batches=10, sample_limit=10, token_display=100):
             # Unpack the batch
             (
                 sample_seqs,
+                ref_seqs,
                 phenotypes,
                 exon_mask,
                 repetitive_mask,
@@ -97,7 +98,13 @@ def test_dataloader(config, num_batches=10, sample_limit=10, token_display=100):
             batch_size = sample_seqs.shape[0]
             logging.info(f"Batch {batch_idx+1}: Successfully loaded {batch_size} samples")
             logging.info(f"  Sample sequence shape:    {sample_seqs.shape}")
+            logging.info(f"  Reference sequence shape: {ref_seqs.shape}")
             logging.info(f"  Phenotype vector shape:   {phenotypes.shape}")
+            logging.info(f"  Exon mask shape:          {exon_mask.shape}")
+            logging.info(f"  Repetitive mask shape:    {repetitive_mask.shape}")
+            logging.info(f"  Positions shape:          {positions.shape}")
+            logging.info(f"  Chromosome:               {chrom}")
+
             # Display samples from the batch
             if batch_size > 0:
                 display_samples(batch, tokenizer, min(sample_limit, batch_size), token_display)
@@ -124,7 +131,6 @@ def display_samples(batch, tokenizer, sample_limit, token_display):
     (
         sample_seqs,
         ref_seqs,
-        lookahead_seqs,
         phenotypes,
         exon_mask,
         repetitive_mask,
@@ -143,8 +149,6 @@ def display_samples(batch, tokenizer, sample_limit, token_display):
         token_sample_size = min(token_display, sample_seqs.shape[1])
         sample_seq_sample = sample_seqs[i, :token_sample_size].tolist()
         ref_seq_sample = ref_seqs[i, :token_sample_size].tolist()
-        lookahead_seqs_sample = lookahead_seqs[i, :token_sample_size].tolist()
-
         # Create match mask by comparing sample and reference sequences
         match_mask = [p == r for p, r in zip(sample_seq_sample, ref_seq_sample)]
         match_binary = "".join(["1" if x else "0" for x in match_mask])
@@ -160,7 +164,6 @@ def display_samples(batch, tokenizer, sample_limit, token_display):
         # Get sample and reference sequences
         sample_str = tokenizer.detokenize(sample_seq_sample)
         ref_str = tokenizer.detokenize(ref_seq_sample)
-        lookahead_str = tokenizer.detokenize(lookahead_seqs_sample)
         # Display all information aligned to positions
         logging.info(f"  Alignment information (first {token_sample_size} positions):")
         logging.info(f"  Sample sequence:     {sample_str}")
@@ -168,7 +171,6 @@ def display_samples(batch, tokenizer, sample_limit, token_display):
         logging.info(f"  Match mask:          {match_binary}")
         logging.info(f"  Exon mask:           {exon_binary}")
         logging.info(f"  Repetitive mask:     {repetitive_binary}")
-        logging.info(f"  Lookahead sequence:  {lookahead_str}")
 
         # Calculate match statistics
         match_count = match_mask.count(True)


### PR DESCRIPTION
Hi Sara,

hier eine Vereinfachung des dataloaders. Dadurch sollte der code besser laufen.
Fall der Fehler weiterhin auftritt, kannst du in der config des dataloaders auf 0 (nicht auf "Null") setzten.

```yaml
dataloader:
      # ...
     num_workers: 0
```
Der Fehler scheint Betriebssystemspezifisch zu sein. Unter Linux / Ubuntu scheint es zu tun.

Folgenden Output solltest du haben:

```
2025-05-12 10:48:37,521 - root - INFO - Created tokenizer with vocabulary size: 6
2025-05-12 10:48:37,521 - root - INFO - Creating dataloader...
2025-05-12 10:48:37,522 - root - INFO - Using VCF data directory: /mnt/c/Users/jules/Documents/PrivateAIM/ResearchProjects/RP-Genomic-Loss/data/chromosomes
2025-05-12 10:48:37,526 - root - INFO - Loaded phenotype data for 5 samples
2025-05-12 10:48:37,539 - root - INFO - Loaded reference genome with 1 chromosomes
2025-05-12 10:48:37,540 - root - INFO - Loading genomic annotations into memory...
2025-05-12 10:48:39,406 - root - INFO - Successfully loaded 13814 exon regions and 79521 repetitive regions into memory
2025-05-12 10:48:39,427 - root - INFO - Generated 20 regions after applying samples_per_sample (4)
2025-05-12 10:48:39,428 - root - INFO - Prepared sampling plan with 20 total regions.
2025-05-12 10:48:39,428 - root - INFO - Dataloader created successfully
2025-05-12 10:48:39,429 - root - INFO - Attempting to load 10 batches of data...
2025-05-12 10:48:39,457 - root - DEBUG - Worker 0/4 processing indices [0, 5) with random offset 781
2025-05-12 10:48:39,459 - root - DEBUG - Worker 1/4 processing indices [5, 10) with random offset 1870
2025-05-12 10:48:39,460 - root - DEBUG - Worker 2/4 processing indices [10, 15) with random offset 1132
2025-05-12 10:48:39,461 - root - DEBUG - Worker 3/4 processing indices [15, 20) with random offset 3054
2025-05-12 10:48:39,500 - root - DEBUG - No variants found for 22:13945838-13949934
2025-05-12 10:48:39,584 - root - DEBUG - No variants found for 22:13064014-13068110
2025-05-12 10:48:39,675 - root - INFO - Batch 1: Successfully loaded 3 samples
2025-05-12 10:48:39,675 - root - INFO -   Sample sequence shape:    torch.Size([3, 4096])
2025-05-12 10:48:39,675 - root - INFO -   Reference sequence shape: torch.Size([3, 4096])
2025-05-12 10:48:39,676 - root - INFO -   Phenotype vector shape:   torch.Size([3, 3])
2025-05-12 10:48:39,676 - root - INFO -   Exon mask shape:          torch.Size([3, 4096])
2025-05-12 10:48:39,676 - root - INFO -   Repetitive mask shape:    torch.Size([3, 4096])
2025-05-12 10:48:39,677 - root - INFO -   Positions shape:          torch.Size([3, 4096])
2025-05-12 10:48:39,677 - root - INFO -   Chromosome:               ('22', '22', '22')
2025-05-12 10:48:39,677 - root - INFO - Sample 1:
2025-05-12 10:48:39,678 - root - INFO -   Region: Chromosome ('22', '22', '22'), Position 0.8341358304023743-0.4034061133861542
2025-05-12 10:48:39,680 - root - INFO -   Alignment information (first 100 positions):
2025-05-12 10:48:39,680 - root - INFO -   Sample sequence:     CAGGCTTCTGCCCATCATATAGTAGGTGACCCCTGAGCACTTACTGTGTGCTGGGTGCCAGGAGGCTCTAGATTGACAATAATCACAGTAAAAGGTAGCC
2025-05-12 10:48:39,681 - root - INFO -   Reference sequence:  CAGGCTTCTGCCCATCATATAGTAGGTGACCCCTGAGCACTTACTGTGTGCTGGGTGCCAGGAGGCTCTAGATTGACAATAATCACAGTAAAAGGTAGCC
2025-05-12 10:48:39,681 - root - INFO -   Match mask:          1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
2025-05-12 10:48:39,681 - root - INFO -   Exon mask:           0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
2025-05-12 10:48:39,681 - root - INFO -   Repetitive mask:     0000000000000000000000000000000000000000000000000000000000000000000000000000000000001111111111111111
2025-05-12 10:48:39,682 - root - INFO -   Match statistics: 100/100 positions match (100.00%)
2025-05-12 10:48:39,692 - root - INFO -   Phenotype vector: tensor([1., 1., 1.])
2
```